### PR TITLE
Add translation support to the analyzer

### DIFF
--- a/grunt/config/po2json.js
+++ b/grunt/config/po2json.js
@@ -1,0 +1,11 @@
+// https://github.com/rockykitamura/grunt-po2json
+module.exports = {
+    all: {
+        options: {
+            format: 'jed1.x',
+            domain: 'js-text-analysis'
+        },
+        src: [ 'languages/*.po' ],
+        dest: 'languages'
+    }
+};

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -1,0 +1,24 @@
+// https://github.com/sindresorhus/grunt-shell
+module.exports = function(grunt) {
+    return {
+        makepot: {
+            potFile: 'languages/js-text-analysis.pot',
+            textdomain: 'js-text-analysis',
+            command: function () {
+                var files;
+
+                files = ['js/*.js', 'js/config/*.js'];
+                files = grunt.file.expand(files);
+
+                return 'xgettext ' +
+                    '--default-domain=<%= shell.makepot.textdomain %>' +
+                    ' -o <%= shell.makepot.potFile %>' +
+                    ' --package-version=<%= pkg.version %> --package-name=<%= pkg.name %>' +
+                    ' --force-po' +
+                    ' --from-code=UTF-8' +
+                    ' --add-comments="translators: "' +
+                    ' ' + files.join( ' ' );
+            }
+        }
+    };
+};

--- a/index.html
+++ b/index.html
@@ -10,8 +10,7 @@
           href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600&amp;subset=latin'/>
     <link rel="stylesheet" href="css/style.css">
 
-    <script type="text/javascript" src="js/config/config.js"></script>
-    <script type="text/javascript" src="js/config/scoring.js"></script>
+    <script type="text/javascript" src="node_modules/jed/jed.js"></script>
 
 
     <script type="text/javascript" src="js/inputGenerator.js"></script>
@@ -48,6 +47,8 @@
                 text: "Start writing your text!"
             }
         };
+
+        YoastSEO_loadEvents();
     </script>
 </head>
 <body class="purple seo">

--- a/js/YoastSEO.js
+++ b/js/YoastSEO.js
@@ -1,19 +1,42 @@
 /**
  * Loader for the analyzer, loads the eventbinder and the elementdefiner
- * @param args
+ * @param {Object} args
  * @constructor
  */
-YoastSEO = function( args ) {
+YoastSEO = function(args) {
     window.YoastSEO_loader = this;
     this.config = args;
     this.inputs = {};
-	this.loadQueue();
+    this.constructI18n(args.translations);
+    this.loadQueue();
     this.stringHelper = new YoastSEO_StringHelper();
     this.source = new this.config.source(args, this);
     this.checkInputs();
     if(!this.config.ajax){
         this.defineElements();
     }
+};
+
+/**
+ * Initializes i18n object based on passed configuration
+ *
+ * @param {Object} translations
+ */
+YoastSEO.prototype.constructI18n = function( translations ) {
+
+    var defaultTranslations = {
+        "domain": "js-text-analysis",
+        "locale_data": {
+            "js-text-analysis": {
+                "": {}
+            }
+        }
+    };
+
+    // Use default object to prevent Jed from erroring out.
+    translations = translations || defaultTranslations;
+
+    this.i18n = new Jed(translations);
 };
 
 /**
@@ -279,6 +302,7 @@ YoastSEO.prototype.runAnalyzer = function() {
 	if( typeof this.pageAnalyzer === "undefined") {
 		var args = this.source.analyzerData;
 		args.queue = this.queue;
+        args.i18n = this.i18n;
 		this.pageAnalyzer = new YoastSEO_Analyzer(args);
 	}else{
 		this.pageAnalyzer.init();

--- a/js/analyzer.js
+++ b/js/analyzer.js
@@ -16,6 +16,17 @@ YoastSEO_Analyzer.prototype.checkConfig = function () {
 	if (typeof this.config.text === "undefined") {
 		this.config.text = "";
 	}
+
+	if (typeof this.config.i18n === "undefined") {
+		this.config.i18n = new Jed({
+			"domain": "js-text-analysis",
+			"locale_data": {
+				"js-text-analysis": {
+					"": {}
+				}
+			}
+		});
+	}
 };
 
 /**

--- a/js/analyzescorer.js
+++ b/js/analyzescorer.js
@@ -1,10 +1,13 @@
 /**
  * inits the analyzerscorer used for scoring of the output from the textanalyzer
+ *
+ * @param {YoastSEO_Analyzer} refObj
  * @constructor
  */
 YoastSEO_AnalyzeScorer = function( refObj ) {
     this.__score = [];
-    this.refObj = refObj;
+    this.refObj= refObj;
+    this.i18n = refObj.config.i18n;
     this.init();
 };
 
@@ -12,7 +15,8 @@ YoastSEO_AnalyzeScorer = function( refObj ) {
  * loads the analyzerScoring from the config file.
  */
 YoastSEO_AnalyzeScorer.prototype.init = function() {
-    this.scoring = analyzerScoring;
+    var scoringConfig = new YoastSEOScoring( this.i18n );
+    this.scoring = scoringConfig.analyzerScoring;
 };
 
 /**

--- a/js/config/scoring.js
+++ b/js/config/scoring.js
@@ -4,7 +4,7 @@ analyzerScoreRating = 9;
  * @param {Jed} i18n
  * @constructor
  */
-var YoastSEOScoring = function( i18n ) {
+YoastSEOScoring = function( i18n ) {
     this.analyzerScoring = [
         {
             scoreName: "wordCount",

--- a/js/config/scoring.js
+++ b/js/config/scoring.js
@@ -1,179 +1,382 @@
 analyzerScoreRating = 9;
-analyzerScoring = [
-    {
-        scoreName: "wordCount",
-        scoreArray: [
-            {min: 300, score: 9, text: "The text contains %1$d words, this is more than the %2$d word recommended minimum."},
-            {min: 250, max: 299, score: 7, text: "The text contains %1$d words, this is slightly below the %2$d word recommended minimum, add a bit more copy."},
-            {min: 200, max: 249, score: 5, text: "The text contains %1$d words, this is below the %2$d word recommended minimum. Add more useful content on this topic for readers."},
-            {min: 100, max: 199, score: -10, text: "The text contains %1$d words, this is below the %2$d word recommended minimum. Add more useful content on this topic for readers."},
-            {min: 0, max: 99, score: -20, text: "The text contains %1$d words. This is far too low and should be increased."}
-        ],
-        replaceArray: [
-            {name: "wordCount",position: "%1$d",source: "matcher"},
-            {name: "recommendedWordcount",position: "%2$d",value: 300}
+/**
+ *
+ * @param {Jed} i18n
+ * @constructor
+ */
+var YoastSEOScoring = function( i18n ) {
+    this.analyzerScoring = [
+        {
+            scoreName: "wordCount",
+            scoreArray: [
+                {
+                    min: 300,
+                    score: 9,
+                    text: i18n.dgettext('js-text-analysis', "The text contains %1$d words, this is more than the %2$d word recommended minimum.")
+                },
+                {
+                    min: 250,
+                    max: 299,
+                    score: 7,
+                    text: i18n.dgettext('js-text-analysis', "The text contains %1$d words, this is slightly below the %2$d word recommended minimum, add a bit more copy.")
+                },
+                {
+                    min: 200,
+                    max: 249,
+                    score: 5,
+                    text: i18n.dgettext('js-text-analysis', "The text contains %1$d words, this is below the %2$d word recommended minimum. Add more useful content on this topic for readers.")
+                },
+                {
+                    min: 100,
+                    max: 199,
+                    score: -10,
+                    text: i18n.dgettext('js-text-analysis', "The text contains %1$d words, this is below the %2$d word recommended minimum. Add more useful content on this topic for readers.")
+                },
+                {
+                    min: 0,
+                    max: 99,
+                    score: -20,
+                    text: i18n.dgettext('js-text-analysis', "The text contains %1$d words. This is far too low and should be increased.")
+                }
+            ],
+            replaceArray: [
+                {name: "wordCount", position: "%1$d", source: "matcher"},
+                {name: "recommendedWordcount", position: "%2$d", value: 300}
 
-        ]
-    },
-    {
-        scoreName: "keywordDensity",
-        scoreArray: [
-            {min: 3.5, score: -50, text: "The keyword density is %1$f%, which is way over the advised 2.5% maximum, the focus keyword was found %1$d times."},
-            {min: 2.5, max: 3.49, score: -10, text: "The keyword density is %1$f%, which is over the advised 2.5% maximum, the focus keyword was found %1$d times."},
-            {min: 0.5, max: 2.49, score: 9, text: "The keyword density is %1$f%, which is great, the focus keyword was found %1$d times."},
-            {min: 0, max: 0.49, score: 4, text: "The keyword density is %1$f%, which is a bit low, the focus keyword was found %1$d times."}
-        ],
-        replaceArray: [
-            {name: "keywordDensity", position: "%1$f", source: "matcher"},
-            {name: "keywordCount", position: "%1$d", sourceObj: ".refObj.__store.keywordCount"}
-        ]
-    },
-    {
-        scoreName: "linkCount",
-        scoreArray: [
-            {matcher: "total", min: 0, max: 0, score: 6, text: "No outbound links appear in this page, consider adding some as appropriate."},
-            {matcher: "totalKeyword", min: 1, score: 2, text: "You\'re linking to another page with the focus keyword you want this page to rank for, consider changing that if you truly want this page to rank."},
-            {type: "externalAllNofollow", score: 7, text: "This page has %2$s outbound link(s), all nofollowed."},
-            {type: "externalHasNofollow", score: 8, text: "This page has %2$s nofollowed link(s) and %3$s normal outbound link(s)."},
-            {type: "externalAllDofollow", score: 9, text: "This page has %1$s outbound link(s)."}
-        ],
-        replaceArray: [
-            {name: "links", position: "%1$s", sourceObj: ".result.externalTotal"},
-            {name: "nofollow", position: "%2$s", sourceObj: ".result.externalNofollow"},
-            {name: "dofollow", position: "%3$s", sourceObj: ".result.externalDofollow"}
-        ]
-    },
-    {
-        scoreName: "fleschReading",
-        scoreArray: [
-            {min: 90, score: 9, text: "<%text%>", resultText: "very easy", note: ""},
-            {min: 80, max: 89.9, score: 9, text: "<%text%>", resultText: "easy", note: ""},
-            {min: 70, max: 79.9, score: 8, text: "<%text%>", resultText: "fairly easy", note: ""},
-            {min: 60, max: 69.9, score: 7, text: "<%text%>", resultText: "ok", note: ""},
-            {min: 50, max: 59.9, score: 6, text: "<%text%>", resultText: "fairly difficult", note: " Try to make shorter sentences to improve readability."},
-            {min: 30, max: 49.9, score: 5, text: "<%text%>", resultText: "difficult", note: " Try to make shorter sentences, using less difficult words to improve readability."},
-            {min: 0, max: 29.9, score: 4, text: "<%text%>", resultText: "very difficult", note: " Try to make shorter sentences, using less difficult words to improve readability."}
-        ],
-        replaceArray: [
-            {name: "scoreText", position: "<%text%>", value: "The copy scores %1$s in the %2$s test, which is considered %3$s to read.%4$s"},
-            {name: "text", position:"%1$s", sourceObj: ".result"},
-            {name: "scoreUrl", position: "%2$s", value: "<a href='https://en.wikipedia.org/wiki/Flesch-Kincaid_readability_test#Flesch_Reading_Ease' target='new'>Flesch Reading Ease</a>"},
-            {name: "resultText", position: "%3$s", scoreObj: "resultText"},
-            {name: "note", position: "%4$s", scoreObj: "note"}
-        ]
-    },
-    {
-        scoreName: "metaDescriptionLength",
-        metaMinLength: 120,
-        metaMaxLength: 156,
-        scoreArray: [
-            {max: 0, score: 1, text: "No meta description has been specified, search engines will display copy from the page instead."},
-            {max: 120, score: 6, text: "The meta description is under %1$d characters, however up to %2$d characters are available."},
-            {min: 156, score: 6, text: "The specified meta description is over %2$d characters, reducing it will ensure the entire description is visible"},
-            {min: 120, max: 156, score: 9, text: "In the specified meta description, consider: How does it compare to the competition? Could it be made more appealing?"}
-        ],
-        replaceArray: [
-            {name: "minCharacters", position: "%1$d", value: 120},
-            {name: "maxCharacters", position: "%2$d", value: 156}
-        ]
-    },
-    {
-        scoreName: "metaDescriptionKeyword",
-        scoreArray: [
-            {min: 1, score: 9, text: "The meta description contains the focus keyword."},
-            {max: 0, score: 3, text: "A meta description has been specified, but it does not contain the focus keyword."}
-        ]
-    },{
-        scoreName: "firstParagraph",
-        scoreArray: [
-            {max: 0, score: 3, text: "The focus keyword doesn\'t appear in the first paragraph of the copy, make sure the topic is clear immediately."},
-            {min: 1, score: 9, text: "The focus keyword appears in the first paragraph of the copy."}
-        ]
-    },{
-        scoreName: "stopwordKeywordCount",
-        scoreArray: [
-            {matcher: "count", min: 1, score: 5, text: "The focus keyword for this page contains one or more %1$s, consider removing them. Found \'%2$s\'."},
-            {matcher: "count", max: 0, score: 0, text: ""}
-        ],
-        replaceArray: [
-            {name: "scoreUrl", position: "%1$s", value: "<a href='https://en.wikipedia.org/wiki/Stop_words' target='new'>stop words</a>"},
-            {name: "stopwords", position: "%2$s", sourceObj: ".result.matches"}
-        ]
-    },{
-        scoreName: "subHeadings",
-        scoreArray: [
-            {matcher: "count", max: 0, score: 7, text: "No subheading tags (like an H2) appear in the copy."},
-            {matcher: "matches", max: 0, score: 3, text: "You have not used your focus keyword in any subheading (such as an H2) in your copy."},
-            {matcher: "matches", min: 1, score: 9, text: "The focus keyword appears in %2$d (out of %1$d) subheadings in the copy. While not a major ranking factor, this is beneficial."}
-        ],
-        replaceArray: [
-            {name: "count", position: "%1$d", sourceObj: ".result.count"},
-            {name: "matches", position: "%2$d", sourceObj: ".result.matches"}
-        ]
-    },{
-        scoreName: "pageTitleLength",
-        scoreArray: [
-            {max: 0, score: 1, text: "Please create a page title."},
-            {max: 40, score: 6, text: "The page title contains %3$d characters, which is less than the recommended minimum of %1$d characters. Use the space to add keyword variations or create compelling call-to-action copy."},
-            {min: 70, score: 6, text: "The page title contains %3$d characters, which is more than the viewable limit of %2$d characters; some words will not be visible to users in your listing."},
-            {min: 40, max: 70, score: 9, text: "The page title is more than %1$d characters and less than the recommended %2$d character limit."}
-        ],
-        replaceArray:[
-            {name: "minLength", position: "%1$d", value: 40},
-            {name: "maxLength", position: "%2$d", value: 70},
-            {name: "length", position: "%3$d", source: "matcher"}
-        ]
-    },{
-        scoreName: "pageTitleKeyword",
-        scoreTitleKeywordLimit: 0,
-        scoreArray:[
-            {matcher: "matches", max: 0, score: 2, text: "The focus keyword '%1$s' does not appear in the page title."},
-            {matcher: "position", max: 1, score: 9, text: "The page title contains the focus keyword, at the beginning which is considered to improve rankings."},
-            {matcher: "position", min: 1, score: 6, text: "The page title contains the focus keyword, but it does not appear at the beginning; try and move it to the beginning."}
-        ],
-        replaceArray:[
-            {name: "keyword", position: "%1$s", sourceObj: ".refObj.config.keyword"}
-        ]
-    },{
-        scoreName: "urlKeyword",
-        scoreArray:[
-            {min: 1, score: 9, text: "The focus keyword appears in the URL for this page."},
-            {max: 0, score: 6, text: "The focus keyword does not appear in the URL for this page. If you decide to rename the URL be sure to check the old URL 301 redirects to the new one!"}
-        ]
-    },{
-        scoreName: "urlLength",
-        scoreArray:[
-            {type: "urlTooLong", score: 5, text: "The slug for this page is a bit long, consider shortening it."}
-        ]
-    },{
-        scoreName: "urlStopwords",
-        scoreArray:[
-            {min: 1, score: 5, text: "The slug for this page contains one or more <a href='http://en.wikipedia.org/wiki/Stop_words' target='new'>stop words</a>, consider removing them."}
-        ]
-    },{
-        scoreName: "imageCount",
-        scoreArray:[
-            {matcher: "total", max: 0, score: 3, text: "No images appear in this page, consider adding some as appropriate."},
-            {matcher: "noAlt", min: 1, score: 5, text: "The images on this page are missing alt tags."},
-            {matcher: "alt", min: 1, score: 5, text: "The images on this page do not have alt tags containing your focus keyword."},
-            {matcher: "altKeyword", min: 1, score: 9, text: "The images on this page contain alt tags with the focus keyword."}
-        ]
-    },{
-        scoreName: "keywordDoubles",
-        scoreArray:[
-            {matcher: "count", max: 0, score: 9, text: "You've never used this focus keyword before, very good."},
-            {matcher: "count", max: 1, score: 6, text: "You've used this focus keyword %1$sonce before%2$s, be sure to make very clear which URL on your site is the most important for this keyword."},
-            {matcher: "count", min: 1, score: 1, text: "You've used this focus keyword %3$s%4$d times before%2$s, it's probably a good idea to read %6$sthis post on cornerstone content%5$s and improve your keyword strategy."}
-        ],
-		replaceArray:[
-			{name: "singleUrl", position: "%1$s", sourceObj: ".refObj.config.postUrl"},
-			{name: "endTag", position: "%2$s", value: "</a>"},
-			{name: "multiUrl", position: "%3$s", sourceObj: ".refObj.config.searchUrl"},
-			{name: "occurrences", position: "%4$d", sourceObj: ".result.count"},
-			{name: "endTag", position: "%5$s", value: "</a>"},
-			{name: "cornerstone", position: "%6$s", value: "<a href='https://yoast.com/cornerstone-content-rank/' target='new'>"},
-			{name: "id", position: "{id}", sourceObj: ".result.id"},
-			{name: "keyword", position: "{keyword}", sourceObj: ".refObj.config.keyword"}
-		]
-    }
-];
+            ]
+        },
+        {
+            scoreName: "keywordDensity",
+            scoreArray: [
+                {
+                    min: 3.5,
+                    score: -50,
+                    text: i18n.dgettext('js-text-analysis', "The keyword density is %1$f%, which is way over the advised 2.5% maximum, the focus keyword was found %1$d times.")
+                },
+                {
+                    min: 2.5,
+                    max: 3.49,
+                    score: -10,
+                    text: i18n.dgettext('js-text-analysis', "The keyword density is %1$f%, which is over the advised 2.5% maximum, the focus keyword was found %1$d times.")
+                },
+                {
+                    min: 0.5,
+                    max: 2.49,
+                    score: 9,
+                    text: i18n.dgettext('js-text-analysis', "The keyword density is %1$f%, which is great, the focus keyword was found %1$d times.")
+                },
+                {
+                    min: 0,
+                    max: 0.49,
+                    score: 4,
+                    text: i18n.dgettext('js-text-analysis', "The keyword density is %1$f%, which is a bit low, the focus keyword was found %1$d times.")
+                }
+            ],
+            replaceArray: [
+                {name: "keywordDensity", position: "%1$f", source: "matcher"},
+                {name: "keywordCount", position: "%1$d", sourceObj: ".refObj.__store.keywordCount"}
+            ]
+        },
+        {
+            scoreName: "linkCount",
+            scoreArray: [
+                {
+                    matcher: "total",
+                    min: 0,
+                    max: 0,
+                    score: 6,
+                    text: i18n.dgettext('js-text-analysis', "No outbound links appear in this page, consider adding some as appropriate.")
+                },
+                {
+                    matcher: "totalKeyword",
+                    min: 1,
+                    score: 2,
+                    text: i18n.dgettext('js-text-analysis', "You\'re linking to another page with the focus keyword you want this page to rank for, consider changing that if you truly want this page to rank.")
+                },
+                {type: "externalAllNofollow", score: 7, text: i18n.dgettext('js-text-analysis', "This page has %2$s outbound link(s), all nofollowed.")},
+                {
+                    type: "externalHasNofollow",
+                    score: 8,
+                    text: i18n.dgettext('js-text-analysis', "This page has %2$s nofollowed link(s) and %3$s normal outbound link(s).")
+                },
+                {type: "externalAllDofollow", score: 9, text: i18n.dgettext('js-text-analysis', "This page has %1$s outbound link(s).")}
+            ],
+            replaceArray: [
+                {name: "links", position: "%1$s", sourceObj: ".result.externalTotal"},
+                {name: "nofollow", position: "%2$s", sourceObj: ".result.externalNofollow"},
+                {name: "dofollow", position: "%3$s", sourceObj: ".result.externalDofollow"}
+            ]
+        },
+        {
+            scoreName: "fleschReading",
+            scoreArray: [
+                {min: 90, score: 9, text: "<%text%>", resultText: "very easy", note: ""},
+                {min: 80, max: 89.9, score: 9, text: "<%text%>", resultText: "easy", note: ""},
+                {min: 70, max: 79.9, score: 8, text: "<%text%>", resultText: "fairly easy", note: ""},
+                {min: 60, max: 69.9, score: 7, text: "<%text%>", resultText: "ok", note: ""},
+                {
+                    min: 50,
+                    max: 59.9,
+                    score: 6,
+                    text: "<%text%>",
+                    resultText: "fairly difficult",
+                    note: i18n.dgettext('js-text-analysis', " Try to make shorter sentences to improve readability.")
+                },
+                {
+                    min: 30,
+                    max: 49.9,
+                    score: 5,
+                    text: "<%text%>",
+                    resultText: "difficult",
+                    note: i18n.dgettext('js-text-analysis', " Try to make shorter sentences, using less difficult words to improve readability.")
+                },
+                {
+                    min: 0,
+                    max: 29.9,
+                    score: 4,
+                    text: "<%text%>",
+                    resultText: "very difficult",
+                    note: i18n.dgettext('js-text-analysis', " Try to make shorter sentences, using less difficult words to improve readability.")
+                }
+            ],
+            replaceArray: [
+                {
+                    name: "scoreText",
+                    position: "<%text%>",
+                    value: i18n.dgettext('js-text-analysis', "The copy scores %1$s in the %2$s test, which is considered %3$s to read.%4$s")
+                },
+                {name: "text", position: "%1$s", sourceObj: ".result"},
+                {
+                    name: "scoreUrl",
+                    position: "%2$s",
+                    value: "<a href='https://en.wikipedia.org/wiki/Flesch-Kincaid_readability_test#Flesch_Reading_Ease' target='new'>Flesch Reading Ease</a>"
+                },
+                {name: "resultText", position: "%3$s", scoreObj: "resultText"},
+                {name: "note", position: "%4$s", scoreObj: "note"}
+            ]
+        },
+        {
+            scoreName: "metaDescriptionLength",
+            metaMinLength: 120,
+            metaMaxLength: 156,
+            scoreArray: [
+                {
+                    max: 0,
+                    score: 1,
+                    text: i18n.dgettext('js-text-analysis', "No meta description has been specified, search engines will display copy from the page instead.")
+                },
+                {
+                    max: 120,
+                    score: 6,
+                    text: i18n.dgettext('js-text-analysis', "The meta description is under %1$d characters, however up to %2$d characters are available.")
+                },
+                {
+                    min: 156,
+                    score: 6,
+                    text: i18n.dgettext('js-text-analysis', "The specified meta description is over %2$d characters, reducing it will ensure the entire description is visible")
+                },
+                {
+                    min: 120,
+                    max: 156,
+                    score: 9,
+                    text: i18n.dgettext('js-text-analysis', "In the specified meta description, consider: How does it compare to the competition? Could it be made more appealing?")
+                }
+            ],
+            replaceArray: [
+                {name: "minCharacters", position: "%1$d", value: 120},
+                {name: "maxCharacters", position: "%2$d", value: 156}
+            ]
+        },
+        {
+            scoreName: "metaDescriptionKeyword",
+            scoreArray: [
+                {min: 1, score: 9, text: i18n.dgettext('js-text-analysis', "The meta description contains the focus keyword.")},
+                {
+                    max: 0,
+                    score: 3,
+                    text: i18n.dgettext('js-text-analysis', "A meta description has been specified, but it does not contain the focus keyword.")
+                }
+            ]
+        }, {
+            scoreName: "firstParagraph",
+            scoreArray: [
+                {
+                    max: 0,
+                    score: 3,
+                    text: i18n.dgettext('js-text-analysis', "The focus keyword doesn\'t appear in the first paragraph of the copy, make sure the topic is clear immediately.")
+                },
+                {min: 1, score: 9, text: i18n.dgettext('js-text-analysis', "The focus keyword appears in the first paragraph of the copy.")}
+            ]
+        }, {
+            scoreName: "stopwordKeywordCount",
+            scoreArray: [
+                {
+                    matcher: "count",
+                    min: 1,
+                    score: 5,
+                    text: i18n.dgettext('js-text-analysis', "The focus keyword for this page contains one or more %1$s, consider removing them. Found \'%2$s\'.")
+                },
+                {matcher: "count", max: 0, score: 0, text: ""}
+            ],
+            replaceArray: [
+                {
+                    name: "scoreUrl",
+                    position: "%1$s",
+                    value: "<a href='https://en.wikipedia.org/wiki/Stop_words' target='new'>stop words</a>"
+                },
+                {name: "stopwords", position: "%2$s", sourceObj: ".result.matches"}
+            ]
+        }, {
+            scoreName: "subHeadings",
+            scoreArray: [
+                {matcher: "count", max: 0, score: 7, text: i18n.dgettext('js-text-analysis', "No subheading tags (like an H2) appear in the copy.")},
+                {
+                    matcher: "matches",
+                    max: 0,
+                    score: 3,
+                    text: i18n.dgettext('js-text-analysis', "You have not used your focus keyword in any subheading (such as an H2) in your copy.")
+                },
+                {
+                    matcher: "matches",
+                    min: 1,
+                    score: 9,
+                    text: i18n.dgettext('js-text-analysis', "The focus keyword appears in %2$d (out of %1$d) subheadings in the copy. While not a major ranking factor, this is beneficial.")
+                }
+            ],
+            replaceArray: [
+                {name: "count", position: "%1$d", sourceObj: ".result.count"},
+                {name: "matches", position: "%2$d", sourceObj: ".result.matches"}
+            ]
+        }, {
+            scoreName: "pageTitleLength",
+            scoreArray: [
+                {max: 0, score: 1, text: i18n.dgettext('js-text-analysis', "Please create a page title.")},
+                {
+                    max: 40,
+                    score: 6,
+                    text: i18n.dgettext('js-text-analysis', "The page title contains %3$d characters, which is less than the recommended minimum of %1$d characters. Use the space to add keyword variations or create compelling call-to-action copy.")
+                },
+                {
+                    min: 70,
+                    score: 6,
+                    text: i18n.dgettext('js-text-analysis', "The page title contains %3$d characters, which is more than the viewable limit of %2$d characters; some words will not be visible to users in your listing.")
+                },
+                {
+                    min: 40,
+                    max: 70,
+                    score: 9,
+                    text: i18n.dgettext('js-text-analysis', "The page title is more than %1$d characters and less than the recommended %2$d character limit.")
+                }
+            ],
+            replaceArray: [
+                {name: "minLength", position: "%1$d", value: 40},
+                {name: "maxLength", position: "%2$d", value: 70},
+                {name: "length", position: "%3$d", source: "matcher"}
+            ]
+        }, {
+            scoreName: "pageTitleKeyword",
+            scoreTitleKeywordLimit: 0,
+            scoreArray: [
+                {
+                    matcher: "matches",
+                    max: 0,
+                    score: 2,
+                    text: i18n.dgettext('js-text-analysis', "The focus keyword '%1$s' does not appear in the page title.")
+                },
+                {
+                    matcher: "position",
+                    max: 1,
+                    score: 9,
+                    text: i18n.dgettext('js-text-analysis', "The page title contains the focus keyword, at the beginning which is considered to improve rankings.")
+                },
+                {
+                    matcher: "position",
+                    min: 1,
+                    score: 6,
+                    text: i18n.dgettext('js-text-analysis', "The page title contains the focus keyword, but it does not appear at the beginning; try and move it to the beginning.")
+                }
+            ],
+            replaceArray: [
+                {name: "keyword", position: "%1$s", sourceObj: ".refObj.config.keyword"}
+            ]
+        }, {
+            scoreName: "urlKeyword",
+            scoreArray: [
+                {min: 1, score: 9, text: i18n.dgettext('js-text-analysis', "The focus keyword appears in the URL for this page.")},
+                {
+                    max: 0,
+                    score: 6,
+                    text: i18n.dgettext('js-text-analysis', "The focus keyword does not appear in the URL for this page. If you decide to rename the URL be sure to check the old URL 301 redirects to the new one!")
+                }
+            ]
+        }, {
+            scoreName: "urlLength",
+            scoreArray: [
+                {type: "urlTooLong", score: 5, text: i18n.dgettext('js-text-analysis', "The slug for this page is a bit long, consider shortening it.")}
+            ]
+        }, {
+            scoreName: "urlStopwords",
+            scoreArray: [
+                {
+                    min: 1,
+                    score: 5,
+                    text: i18n.dgettext('js-text-analysis', "The slug for this page contains one or more <a href='http://en.wikipedia.org/wiki/Stop_words' target='new'>stop words</a>, consider removing them.")
+                }
+            ]
+        }, {
+            scoreName: "imageCount",
+            scoreArray: [
+                {
+                    matcher: "total",
+                    max: 0,
+                    score: 3,
+                    text: i18n.dgettext('js-text-analysis', "No images appear in this page, consider adding some as appropriate.")
+                },
+                {matcher: "noAlt", min: 1, score: 5, text: i18n.dgettext('js-text-analysis', "The images on this page are missing alt tags.")},
+                {
+                    matcher: "alt",
+                    min: 1,
+                    score: 5,
+                    text: i18n.dgettext('js-text-analysis', "The images on this page do not have alt tags containing your focus keyword.")
+                },
+                {
+                    matcher: "altKeyword",
+                    min: 1,
+                    score: 9,
+                    text: i18n.dgettext('js-text-analysis', "The images on this page contain alt tags with the focus keyword.")
+                }
+            ]
+        }, {
+            scoreName: "keywordDoubles",
+            scoreArray: [
+                {matcher: "count", max: 0, score: 9, text: i18n.dgettext('js-text-analysis', "You've never used this focus keyword before, very good.")},
+                {
+                    matcher: "count",
+                    max: 1,
+                    score: 6,
+                    text: i18n.dgettext('js-text-analysis', "You've used this focus keyword %1$sonce before%2$s, be sure to make very clear which URL on your site is the most important for this keyword.")
+                },
+                {
+                    matcher: "count",
+                    min: 1,
+                    score: 1,
+                    text: i18n.dgettext('js-text-analysis', "You've used this focus keyword %3$s%4$d times before%2$s, it's probably a good idea to read %6$sthis post on cornerstone content%5$s and improve your keyword strategy.")
+                }
+            ],
+            replaceArray: [
+                {name: "singleUrl", position: "%1$s", sourceObj: ".refObj.config.postUrl"},
+                {name: "endTag", position: "%2$s", value: "</a>"},
+                {name: "multiUrl", position: "%3$s", sourceObj: ".refObj.config.searchUrl"},
+                {name: "occurrences", position: "%4$d", sourceObj: ".result.count"},
+                {name: "endTag", position: "%5$s", value: "</a>"},
+                {
+                    name: "cornerstone",
+                    position: "%6$s",
+                    value: "<a href='https://yoast.com/cornerstone-content-rank/' target='new'>"
+                },
+                {name: "id", position: "{id}", sourceObj: ".result.id"},
+                {name: "keyword", position: "{keyword}", sourceObj: ".refObj.config.keyword"}
+            ]
+        }
+    ];
+}

--- a/languages/js-text-analysis.pot
+++ b/languages/js-text-analysis.pot
@@ -1,0 +1,263 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Yoast-text-analysis 0.0.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-08-04 11:25+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: js/config/scoring.js:15
+msgid ""
+"The text contains %1$d words, this is more than the %2$d word recommended "
+"minimum."
+msgstr ""
+
+#: js/config/scoring.js:21
+msgid ""
+"The text contains %1$d words, this is slightly below the %2$d word "
+"recommended minimum, add a bit more copy."
+msgstr ""
+
+#: js/config/scoring.js:27 js/config/scoring.js:33
+msgid ""
+"The text contains %1$d words, this is below the %2$d word recommended "
+"minimum. Add more useful content on this topic for readers."
+msgstr ""
+
+#: js/config/scoring.js:39
+msgid ""
+"The text contains %1$d words. This is far too low and should be increased."
+msgstr ""
+
+#: js/config/scoring.js:54
+msgid ""
+"The keyword density is %1$f%, which is way over the advised 2.5% maximum, "
+"the focus keyword was found %1$d times."
+msgstr ""
+
+#: js/config/scoring.js:60
+msgid ""
+"The keyword density is %1$f%, which is over the advised 2.5% maximum, the "
+"focus keyword was found %1$d times."
+msgstr ""
+
+#: js/config/scoring.js:66
+msgid ""
+"The keyword density is %1$f%, which is great, the focus keyword was found "
+"%1$d times."
+msgstr ""
+
+#: js/config/scoring.js:72
+msgid ""
+"The keyword density is %1$f%, which is a bit low, the focus keyword was "
+"found %1$d times."
+msgstr ""
+
+#: js/config/scoring.js:88
+msgid ""
+"No outbound links appear in this page, consider adding some as appropriate."
+msgstr ""
+
+#: js/config/scoring.js:94
+msgid ""
+"You're linking to another page with the focus keyword you want this page to "
+"rank for, consider changing that if you truly want this page to rank."
+msgstr ""
+
+#: js/config/scoring.js:96
+msgid "This page has %2$s outbound link(s), all nofollowed."
+msgstr ""
+
+#: js/config/scoring.js:100
+msgid "This page has %2$s nofollowed link(s) and %3$s normal outbound link(s)."
+msgstr ""
+
+#: js/config/scoring.js:102
+msgid "This page has %1$s outbound link(s)."
+msgstr ""
+
+#: js/config/scoring.js:123
+msgid " Try to make shorter sentences to improve readability."
+msgstr ""
+
+#: js/config/scoring.js:131 js/config/scoring.js:139
+msgid ""
+" Try to make shorter sentences, using less difficult words to improve "
+"readability."
+msgstr ""
+
+#: js/config/scoring.js:146
+msgid ""
+"The copy scores %1$s in the %2$s test, which is considered %3$s to read.%4$s"
+msgstr ""
+
+#: js/config/scoring.js:166
+msgid ""
+"No meta description has been specified, search engines will display copy "
+"from the page instead."
+msgstr ""
+
+#: js/config/scoring.js:171
+msgid ""
+"The meta description is under %1$d characters, however up to %2$d characters "
+"are available."
+msgstr ""
+
+#: js/config/scoring.js:176
+msgid ""
+"The specified meta description is over %2$d characters, reducing it will "
+"ensure the entire description is visible"
+msgstr ""
+
+#: js/config/scoring.js:182
+msgid ""
+"In the specified meta description, consider: How does it compare to the "
+"competition? Could it be made more appealing?"
+msgstr ""
+
+#: js/config/scoring.js:193
+msgid "The meta description contains the focus keyword."
+msgstr ""
+
+#: js/config/scoring.js:197
+msgid ""
+"A meta description has been specified, but it does not contain the focus "
+"keyword."
+msgstr ""
+
+#: js/config/scoring.js:206
+msgid ""
+"The focus keyword doesn't appear in the first paragraph of the copy, make "
+"sure the topic is clear immediately."
+msgstr ""
+
+#: js/config/scoring.js:208
+msgid "The focus keyword appears in the first paragraph of the copy."
+msgstr ""
+
+#: js/config/scoring.js:217
+msgid ""
+"The focus keyword for this page contains one or more %1$s, consider removing "
+"them. Found '%2$s'."
+msgstr ""
+
+#: js/config/scoring.js:232
+msgid "No subheading tags (like an H2) appear in the copy."
+msgstr ""
+
+#: js/config/scoring.js:237
+msgid ""
+"You have not used your focus keyword in any subheading (such as an H2) in "
+"your copy."
+msgstr ""
+
+#: js/config/scoring.js:243
+msgid ""
+"The focus keyword appears in %2$d (out of %1$d) subheadings in the copy. "
+"While not a major ranking factor, this is beneficial."
+msgstr ""
+
+#: js/config/scoring.js:253
+msgid "Please create a page title."
+msgstr ""
+
+#: js/config/scoring.js:257
+msgid ""
+"The page title contains %3$d characters, which is less than the recommended "
+"minimum of %1$d characters. Use the space to add keyword variations or "
+"create compelling call-to-action copy."
+msgstr ""
+
+#: js/config/scoring.js:262
+msgid ""
+"The page title contains %3$d characters, which is more than the viewable "
+"limit of %2$d characters; some words will not be visible to users in your "
+"listing."
+msgstr ""
+
+#: js/config/scoring.js:268
+msgid ""
+"The page title is more than %1$d characters and less than the recommended "
+"%2$d character limit."
+msgstr ""
+
+#: js/config/scoring.js:284
+msgid "The focus keyword '%1$s' does not appear in the page title."
+msgstr ""
+
+#: js/config/scoring.js:290
+msgid ""
+"The page title contains the focus keyword, at the beginning which is "
+"considered to improve rankings."
+msgstr ""
+
+#: js/config/scoring.js:296
+msgid ""
+"The page title contains the focus keyword, but it does not appear at the "
+"beginning; try and move it to the beginning."
+msgstr ""
+
+#: js/config/scoring.js:305
+msgid "The focus keyword appears in the URL for this page."
+msgstr ""
+
+#: js/config/scoring.js:309
+msgid ""
+"The focus keyword does not appear in the URL for this page. If you decide to "
+"rename the URL be sure to check the old URL 301 redirects to the new one!"
+msgstr ""
+
+#: js/config/scoring.js:315
+msgid "The slug for this page is a bit long, consider shortening it."
+msgstr ""
+
+#: js/config/scoring.js:323
+msgid ""
+"The slug for this page contains one or more <a href='http://en.wikipedia.org/"
+"wiki/Stop_words' target='new'>stop words</a>, consider removing them."
+msgstr ""
+
+#: js/config/scoring.js:333
+msgid "No images appear in this page, consider adding some as appropriate."
+msgstr ""
+
+#: js/config/scoring.js:335
+msgid "The images on this page are missing alt tags."
+msgstr ""
+
+#: js/config/scoring.js:340
+msgid ""
+"The images on this page do not have alt tags containing your focus keyword."
+msgstr ""
+
+#: js/config/scoring.js:346
+msgid "The images on this page contain alt tags with the focus keyword."
+msgstr ""
+
+#: js/config/scoring.js:352
+msgid "You've never used this focus keyword before, very good."
+msgstr ""
+
+#: js/config/scoring.js:357
+msgid ""
+"You've used this focus keyword %1$sonce before%2$s, be sure to make very "
+"clear which URL on your site is the most important for this keyword."
+msgstr ""
+
+#: js/config/scoring.js:363
+msgid ""
+"You've used this focus keyword %3$s%4$d times before%2$s, it's probably a "
+"good idea to read %6$sthis post on cornerstone content%5$s and improve your "
+"keyword strategy."
+msgstr ""

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "grunt-jscs": "^1.6.0",
     "grunt-jsonlint": "^1.0.4",
     "grunt-jsvalidate": "^0.2.2",
+    "grunt-po2json": "^0.3.0",
+    "grunt-shell": "^1.1.2",
     "io.js": "0.0.0",
     "jasmine": "~2.2.1",
     "jsdom": "^5.4.3",
@@ -36,5 +38,8 @@
   },
   "bugs": {
     "url": "https://github.com/Yoast/js-text-analysis/issues"
+  },
+  "dependencies": {
+    "jed": "^1.1.0"
   }
 }

--- a/spec/helpers/i18n.js
+++ b/spec/helpers/i18n.js
@@ -1,0 +1,2 @@
+// Make sure the Jed object is globally available
+Jed = require('jed');


### PR DESCRIPTION
We use Jed for this, this seemed like the most popular js gettext
library. For this we have to pass a Jed object to the scoring.js config,
so we do that now. We instantiate the Jed object in YoastSEO. The
responsibility for loading the translations is outside of YoastSEO, so
the calling library has to pass in a javascript object with
translations.

To parse the files for strings we use `grunt-shell` that calls
`xgettext`. We first tried `grunt-jspot`/`jspot` but that didn't support
translator comment and we definitely need them. Also add the parsed .pot
file.

After we receive .po files for all languages we can transform them to
.json using po2json with the `jed1.x` format for jed.