### PR TITLE
Rename Initializer to App, have an initialize function construct it and assign it.

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
             <script type="text/javascript" src="js/analyzescorer.js"></script>
             <script type="text/javascript" src="js/preprocessor.js"></script>
             <script type="text/javascript" src="js/stringhelper.js"></script>
-            <script type="text/javascript" src="js/initializer.js"></script>
+            <script type="text/javascript" src="js/app.js"></script>
             <script type="text/javascript" src="js/scoreFormatter.js"></script>
     <script>
         YoastSEO = ( "undefined" === typeof YoastSEO ) ? {} : YoastSEO;
@@ -50,7 +50,7 @@
             }
         };
 
-        YoastSEO.loadAnalyzerEvents();
+        YoastSEO.initialize();
     </script>
 </head>
 <body class="purple seo">
@@ -97,12 +97,12 @@
                     <div class="breadcrumb" itemprop="breadcrumb">
 								<span xmlns:v="http://rdf.data-vocabulary.org/#">
 									<span typeof="v:Breadcrumb">
-										<a href="https://yoast.com" rel="v:url" property="v:title">Home</a> 
-										<span class="sep">▸</span> 
+										<a href="https://yoast.com" rel="v:url" property="v:title">Home</a>
+										<span class="sep">▸</span>
 										<span rel="v:child" typeof="v:Breadcrumb">
 											<a href="https://yoast.com/wordpress/plugins/seo/" rel="v:url"
                                                property="v:title">Yoast SEO plugin</a>
-											<span class="sep">▸</span> 
+											<span class="sep">▸</span>
 											<span class="breadcrumb_last">Real Time Content Analysis</span>
 										</span>
 									</span>

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,5 @@
 /* jshint browser: true */
-/* global YoastSEO: true, YoastSEO_loader: true */
+/* global YoastSEO: true, YoastSEO.app: true */
 /* global Jed */
 YoastSEO = ( "undefined" === typeof YoastSEO ) ? {} : YoastSEO;
 
@@ -11,8 +11,8 @@ YoastSEO = ( "undefined" === typeof YoastSEO ) ? {} : YoastSEO;
  *
  * @constructor
  */
-YoastSEO.Initializer = function( args ) {
-	window.YoastSEO_loader = this;
+YoastSEO.App = function( args ) {
+	window.YoastSEO.app = this;
 	this.config = args;
 	this.inputs = {};
 	this.constructI18n( args.translations );
@@ -30,7 +30,7 @@ YoastSEO.Initializer = function( args ) {
  *
  * @param {Object} translations
  */
-YoastSEO.Initializer.prototype.constructI18n = function( translations ) {
+YoastSEO.App.prototype.constructI18n = function( translations ) {
 
 	var defaultTranslations = {
 		"domain": "js-text-analysis",
@@ -50,7 +50,7 @@ YoastSEO.Initializer.prototype.constructI18n = function( translations ) {
 /**
  * inits YoastSEO, calls element definer and snippet preview creater
  */
-YoastSEO.Initializer.prototype.init = function() {
+YoastSEO.App.prototype.init = function() {
 	this.defineElements();
 	this.createSnippetPreview();
 };
@@ -58,7 +58,7 @@ YoastSEO.Initializer.prototype.init = function() {
 /**
  * loads the queue from the analyzer if no queue is defined.
  */
-YoastSEO.Initializer.prototype.loadQueue = function() {
+YoastSEO.App.prototype.loadQueue = function() {
 	if ( typeof this.queue === "undefined" ) {
 		this.queue = YoastSEO.analyzerConfig.queue;
 	}
@@ -68,7 +68,7 @@ YoastSEO.Initializer.prototype.loadQueue = function() {
  * Adds function to the analyzer queue. Function must be in the Analyzer prototype to be added.
  * @param func
  */
-YoastSEO.Initializer.prototype.addToQueue = function( func ) {
+YoastSEO.App.prototype.addToQueue = function( func ) {
 	if ( typeof YoastSEO.Analyzer.prototype[ func ] === "function" ) {
 		this.queue.push( func );
 	}
@@ -78,7 +78,7 @@ YoastSEO.Initializer.prototype.addToQueue = function( func ) {
  * Removes function from queue if it is currently in the queue.
  * @param func
  */
-YoastSEO.Initializer.prototype.removeFromQueue = function( func ) {
+YoastSEO.App.prototype.removeFromQueue = function( func ) {
 	var funcIndex = this.queue.indexOf( func );
 	if ( funcIndex > -1 ) {
 		this.queue.splice( funcIndex, 1 );
@@ -88,7 +88,7 @@ YoastSEO.Initializer.prototype.removeFromQueue = function( func ) {
 /**
  * creates the elements for the snippetPreview
  */
-YoastSEO.Initializer.prototype.createSnippetPreview = function() {
+YoastSEO.App.prototype.createSnippetPreview = function() {
 	var targetElement = document.getElementById( this.config.targets.snippet );
 	var div = document.createElement( "div" );
 	div.id = "snippet_preview";
@@ -105,7 +105,7 @@ YoastSEO.Initializer.prototype.createSnippetPreview = function() {
  * creates the title elements in the snippetPreview and appends to target
  * @param target
  */
-YoastSEO.Initializer.prototype.createSnippetPreviewTitle = function( target ) {
+YoastSEO.App.prototype.createSnippetPreviewTitle = function( target ) {
 	var elem = document.createElement( "div" );
 	elem.className = "snippet_container";
 	elem.id = "title_container";
@@ -124,7 +124,7 @@ YoastSEO.Initializer.prototype.createSnippetPreviewTitle = function( target ) {
  * creates the URL elements in the snippetPreview and appends to target
  * @param target
  */
-YoastSEO.Initializer.prototype.createSnippetPreviewUrl = function( target ) {
+YoastSEO.App.prototype.createSnippetPreviewUrl = function( target ) {
 	var elem = document.createElement( "div" );
 	elem.className = "snippet_container";
 	elem.id = "url_container";
@@ -146,7 +146,7 @@ YoastSEO.Initializer.prototype.createSnippetPreviewUrl = function( target ) {
  * creates the meta description elements in the snippetPreview and appends to target
  * @param target
  */
-YoastSEO.Initializer.prototype.createSnippetPreviewMeta = function( target ) {
+YoastSEO.App.prototype.createSnippetPreviewMeta = function( target ) {
 	var elem = document.createElement( "div" );
 	elem.className = "snippet_container";
 	elem.id = "meta_container";
@@ -163,7 +163,7 @@ YoastSEO.Initializer.prototype.createSnippetPreviewMeta = function( target ) {
 /**
  * defines the target element to be used for the output on the page
  */
-YoastSEO.Initializer.prototype.defineElements = function() {
+YoastSEO.App.prototype.defineElements = function() {
 	this.target = document.getElementById( this.config.targets.output );
 	for ( var i = 0; i < this.config.elementTarget.length; i++ ) {
 		var elem = document.getElementById( this.config.elementTarget[ i ] );
@@ -174,7 +174,7 @@ YoastSEO.Initializer.prototype.defineElements = function() {
 	}
 };
 
-YoastSEO.Initializer.prototype.createEditIcon = function( elem, id ) {
+YoastSEO.App.prototype.createEditIcon = function( elem, id ) {
 	var div = document.createElement( "div" );
 	div.className = "editIcon";
 	div.id = "editIcon_" + id;
@@ -186,21 +186,21 @@ YoastSEO.Initializer.prototype.createEditIcon = function( elem, id ) {
  * gets the values from the inputfields. The values from these fields are used as input for the
  * analyzer.
  */
-YoastSEO.Initializer.prototype.getAnalyzerInput = function() {
+YoastSEO.App.prototype.getAnalyzerInput = function() {
 	this.inputs = this.source.getAnalyzerInput();
 };
 
 /**
  * binds the events to the generated inputs. Binds events on the snippetinputs if editable
  */
-YoastSEO.Initializer.prototype.bindEvent = function() {
+YoastSEO.App.prototype.bindEvent = function() {
 	this.source.bindElementEvents();
 };
 
 /**
  * binds the analyzeTimer function to the input of the targetElement on the page.
  */
-YoastSEO.Initializer.prototype.bindInputEvent = function() {
+YoastSEO.App.prototype.bindInputEvent = function() {
 	for ( var i = 0; i < this.config.elementTarget.length; i++ ) {
 		var elem = document.getElementById( this.config.elementTarget[ i ] );
 		elem.addEventListener( "input", this.analyzeTimer );
@@ -210,7 +210,7 @@ YoastSEO.Initializer.prototype.bindInputEvent = function() {
 /**
  * binds the reloadSnippetText function to the blur of the snippet inputs.
  */
-YoastSEO.Initializer.prototype.bindSnippetEvents = function() {
+YoastSEO.App.prototype.bindSnippetEvents = function() {
 	var snippetElem = document.getElementById( this.config.targets.snippet );
 	snippetElem.refObj = this;
 	var elems = [ "meta", "cite", "title" ];
@@ -225,7 +225,7 @@ YoastSEO.Initializer.prototype.bindSnippetEvents = function() {
 /**
  * runs the rerender function of the snippetPreview if that object is defined.
  */
-YoastSEO.Initializer.prototype.reloadSnippetText = function() {
+YoastSEO.App.prototype.reloadSnippetText = function() {
 	if ( typeof this.snippetPreview !== "undefined" ) {
 		this.snippetPreview.reRender();
 	}
@@ -236,7 +236,7 @@ YoastSEO.Initializer.prototype.reloadSnippetText = function() {
  * at every keystroke checks the reference object, so this function can be called from anywhere,
  * without problems with different scopes.
  */
-YoastSEO.Initializer.prototype.analyzeTimer = function() {
+YoastSEO.App.prototype.analyzeTimer = function() {
 	var refObj = this.__refObj;
 
 	//if __refObj is not found (used on elements), use refObj
@@ -256,13 +256,13 @@ YoastSEO.Initializer.prototype.analyzeTimer = function() {
  * calls the getInput function to retrieve values from inputs. If the keyword is empty calls
  * message, if keyword is filled, runs the analyzer
  */
-YoastSEO.Initializer.prototype.checkInputs = function() {
-	var refObj = window.YoastSEO_loader;
+YoastSEO.App.prototype.checkInputs = function() {
+	var refObj = window.YoastSEO.app;
 	refObj.getAnalyzerInput();
 };
 
-YoastSEO.Initializer.prototype.runAnalyzerCallback = function() {
-	var refObj = window.YoastSEO_loader;
+YoastSEO.App.prototype.runAnalyzerCallback = function() {
+	var refObj = window.YoastSEO.app;
 	if ( refObj.source.analyzerData.keyword === "" ) {
 		refObj.showMessage();
 	} else {
@@ -273,7 +273,7 @@ YoastSEO.Initializer.prototype.runAnalyzerCallback = function() {
 /**
  * used when no keyword is filled in, it will display a message in the target element
  */
-YoastSEO.Initializer.prototype.showMessage = function() {
+YoastSEO.App.prototype.showMessage = function() {
 	this.target.innerHTML = "";
 	var messageDiv = document.createElement( "div" );
 	messageDiv.className = "wpseo_msg";
@@ -285,14 +285,14 @@ YoastSEO.Initializer.prototype.showMessage = function() {
 /**
  * sets the startTime timestamp
  */
-YoastSEO.Initializer.prototype.startTime = function() {
+YoastSEO.App.prototype.startTime = function() {
 	this.startTimestamp = new Date().getTime();
 };
 
 /**
  * sets the endTime timestamp and compares with startTime to determine typeDelayincrease.
  */
-YoastSEO.Initializer.prototype.endTime = function() {
+YoastSEO.App.prototype.endTime = function() {
 	this.endTimestamp = new Date().getTime();
 	if ( this.endTimestamp - this.startTimestamp > this.config.typeDelay ) {
 		if ( this.config.typeDelay < ( this.config.maxTypeDelay - this.config.typeDelayStep ) ) {
@@ -305,7 +305,7 @@ YoastSEO.Initializer.prototype.endTime = function() {
  * inits a new pageAnalyzer with the inputs from the getInput function and calls the scoreFormatter
  * to format outputs.
  */
-YoastSEO.Initializer.prototype.runAnalyzer = function() {
+YoastSEO.App.prototype.runAnalyzer = function() {
 	if ( this.config.dynamicDelay ) {
 		this.startTime();
 	}
@@ -327,10 +327,10 @@ YoastSEO.Initializer.prototype.runAnalyzer = function() {
 /**
  * run at pageload to init the analyzeLoader for pageAnalysis.
  */
-YoastSEO.loadAnalyzerEvents = function() {
+YoastSEO.initialize = function() {
 	if ( document.readyState === "complete" ) {
-		YoastSEO_loader = new YoastSEO.Initializer( YoastSEO.analyzerArgs );
+		YoastSEO.app = new YoastSEO.App( YoastSEO.analyzerArgs );
 	} else {
-		setTimeout( YoastSEO.loadAnalyzerEvents, 50 );
+		setTimeout( YoastSEO.initialize, 50 );
 	}
 };

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,5 @@
 /* jshint browser: true */
-/* global YoastSEO: true, YoastSEO.app: true */
+/* global YoastSEO: true */
 /* global Jed */
 YoastSEO = ( "undefined" === typeof YoastSEO ) ? {} : YoastSEO;
 
@@ -325,7 +325,7 @@ YoastSEO.App.prototype.runAnalyzer = function() {
 };
 
 /**
- * run at pageload to init the analyzeLoader for pageAnalysis.
+ * run at pageload to init the App for pageAnalysis.
  */
 YoastSEO.initialize = function() {
 	if ( document.readyState === "complete" ) {


### PR DESCRIPTION
@atimmer this feels slightly more intuitive to me.

I guess we are initializing a content analysis app here. Let's just name it that, construct it, let it have its init function etc.

No more desolate Globals. Everything now contained by `YoastSEO`.